### PR TITLE
changed DIRS to respect XDG specifications

### DIFF
--- a/tfw.sh
+++ b/tfw.sh
@@ -13,8 +13,11 @@ GPG_OPTS=( $GESTALT_GPG_OPTS "--quiet" "--yes" "--compress-algo=none" "--no-encr
 # Check which variant of `date` is present on the system.
 date --version >/dev/null 2>&1 && DATE_VARIANT="GNU" || DATE_VARIANT="BSD"
 
-CONFIG_DIR="$HOME/.config/$APP_NAME"
-ENTRY_DIR="$CONFIG_DIR/entries"
+# Check if XDG_DATA_HOME exists
+[ -z "$XDG_DATA_HOME" ] && XDG_DATA_HOME="$HOME/.local/share"
+
+CONFIG_DIR="${XDG_DATA_HOME}/$APP_NAME"
+ENTRY_DIR="${XDG_DATA_HOME}/$APP_NAME/entries"
 DATE_FORMAT="%c"
 
 #


### PR DESCRIPTION
According to the [XDG specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) user specific data should be in $XDG_DATA_HOME (default $HOME/.local/share) and only configuration files should be in $XDG_CONFIG_HOME.

The journal entries are certainly not configuration files. And after thinking for a bit, the gpg id hardly qualifies as a configuration file either.