### PR TITLE
add trash-cli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ ante elementum [dolor], quis faucibus tortor risus vel sem. Aliquam varius
 
 #### remove|rm \<selector\>...
 
-Remove the selected entries. Prompt for confirmation when attempting to remove multiple entries.
+Remove the selected entries. Uses [trash-cli](https://github.com/andreafrancia/trash-cli/) if installed, otherwise permanently deletes the file. Prompts for confirmation when attempting to remove multiple entries.
 
 **NOTE:** The indices are not IDs. When an entry is removed from the list, the entry immediately following it takes its place. When in doubt, run `ls` again before removing more entries.
 

--- a/tfw.sh
+++ b/tfw.sh
@@ -472,7 +472,7 @@ cmd_remove() {
 	fi
 
   local TRASH_CMD="rm -f"
-  which trashh-put &> /dev/null &&
+  which trash-put &> /dev/null &&
     TRASH_CMD="trash-put"
 
 	for i in "${SELECTION[@]}"; do

--- a/tfw.sh
+++ b/tfw.sh
@@ -471,9 +471,9 @@ cmd_remove() {
 		yesno "Do you wish to proceed?" || die "Aborted."
 	fi
 
-  which trash-put &> /dev/null &&
-    TRASH_CMD="trash-put" ||
-    TRASH_CMD="rm -f"
+  local TRASH_CMD="rm -f"
+  which trashh-put &> /dev/null &&
+    TRASH_CMD="trash-put"
 
 	for i in "${SELECTION[@]}"; do
 		${TRASH_CMD} "$ENTRY_DIR/${FILENAMES[$i]}"

--- a/tfw.sh
+++ b/tfw.sh
@@ -451,8 +451,8 @@ cmd_view() {
 	printf "$text" | fold -w $width -s | less -R +1g
 }
 
-# cmd_remove() permanently deletes selected entries. Prompts for confirmation
-# when multiple entries are selected.
+# cmd_remove() uses trash-cli if found otherwise permanently deletes selected entries.
+# Prompts for confirmation when multiple entries are selected.
 cmd_remove() {
 	[[ "$#" -eq 0 ]] && die "Usage: $APP_NAME remove|rm <selector>..."
 
@@ -471,8 +471,12 @@ cmd_remove() {
 		yesno "Do you wish to proceed?" || die "Aborted."
 	fi
 
+  which trash-put &> /dev/null &&
+    TRASH_CMD="trash-put" ||
+    TRASH_CMD="rm -f"
+
 	for i in "${SELECTION[@]}"; do
-		rm -f "$ENTRY_DIR/${FILENAMES[$i]}"
+		${TRASH_CMD} "$ENTRY_DIR/${FILENAMES[$i]}"
 	done
 }
 


### PR DESCRIPTION
The current way of removing entries is a bit error prone. If the user has [trash-cli](https://github.com/andreafrancia/trash-cli/) installed, this makes it so they don't have to bang their head after accidentally deleting the wrong entry.